### PR TITLE
Add 'GitHub Skills' activity (issue #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -77,6 +77,14 @@ activities = {
     }
 }
 
+# Added GitHub Skills activity (requested in issue #6)
+activities["GitHub Skills"] = {
+    "description": "Hands-on workshops to learn Git, GitHub, and collaboration practices",
+    "schedule": "Saturdays, 10:00 AM - 12:00 PM",
+    "max_participants": 25,
+    "participants": []
+}
+
 
 @app.get("/")
 def root():


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity requested in issue #6. It adds a new in-memory activity entry so students can sign up via the existing UI/API.\n\nFiles changed:\n- src/app.py: added a new activity entry for "GitHub Skills" (description, schedule, max_participants).\n\nThis is a small, fast fix to ensure the announced activity is available while we work on moving activities to persistent storage (Phase A).